### PR TITLE
changed line 105 in parallel shell in node modules folder. 

### DIFF
--- a/node_modules/parallelshell/index.js
+++ b/node_modules/parallelshell/index.js
@@ -102,7 +102,7 @@ cmds.forEach(function (cmd) {
       cmd = "exec "+cmd;
     }
     var child = spawn(sh,[shFlag,cmd], {
-        cwd: process.versions.node < '8.0.0' ? process.cwd : process.cwd(),
+        cwd: parseInt(process.versions.node) < 8 ? process.cwd : process.cwd(),
         env: process.env,
         stdio: ['pipe', process.stdout, process.stderr]
     })


### PR DESCRIPTION
Usually we shouldn't touch the node modules folder. In this case we needed to. This has something to do with the node version installed on your machine. You should be able to run it now.

